### PR TITLE
Fix typescript error TS7006 from implicit 'any' type in main.ts

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -40,7 +40,7 @@ const DEFAULT_SETTINGS: PluginSettings = {
 	timeout: 10000,	// 10s
 }
 
-function formatError(err) {
+function formatError(err: any) {
 	let html = '<div>'
 	if (err.signal === 'SIGTERM') {
 		html += 'Child process got terminated. Is the timeout large enough?'


### PR DESCRIPTION
Solves the following error I had while building with suggested command (on mac)

```
main.ts:43:22 - error TS7006: Parameter 'err' implicitly has an 'any' type.

43 function formatError(err) {
                        ~~~
```
