### PR TITLE
Use registerMarkdownCodeBlockProcessor

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -53,6 +53,9 @@ export default class MyPlugin extends Plugin {
 	settings: PluginSettings;
 
 	async onload() {
+		// Add an alias for "tikz" and "tikz-render" so that syntax highlighting works in tikz-render code blocks
+		window.CodeMirror.modeInfo.push({name: "Tikz", mime: "text/x-latex", mode: "stex", alias: ["tikz-render"]},)
+
 		await this.loadSettings();
 
 		this.registerMarkdownCodeBlockProcessor('tikz-render', (source, el, ctx) => {

--- a/main.ts
+++ b/main.ts
@@ -107,7 +107,7 @@ export default class MyPlugin extends Plugin {
 		this.addSettingTab(new SettingTab(this.app, this));
 	}
 
-	renderTikz2SVG(source: string) {
+	renderTikz(source: string) {
 
 		// Build latex source code with standalone class
 		const latex_source = `\\documentclass[tikz]{standalone}
@@ -119,7 +119,7 @@ ${this.settings.preamble}
 \\end{document}`;
 
 		// Render latex
-		return this.renderLatex2SVG(latex_source);
+		return this.renderLatex(latex_source);
 	}
 
 	renderTikzToContainer(source: string, container: HTMLElement) {
@@ -134,12 +134,12 @@ ${this.settings.preamble}
 		})
 	}
 
-	renderLatex2SVG(source: string) {
+	renderLatex(source: string) {
 		// Build latex:
 		//  - create temp folder
 		// 	- write file to temp folder
 		//	- call pdflatex and pdf2svg
-		// 	- load svg file
+		// 	- return img element with an app://local link to the rendered file
 		return new Promise((resolve, reject) => {
 			temp.mkdir('obsidian-tikz', (err: ErrnoException | null, dirPath: string) => {
 				const inputPath = path.join(dirPath, 'input.tex')
@@ -151,10 +151,7 @@ ${this.settings.preamble}
 
 					exec(command, {cwd: dirPath, timeout: this.settings.timeout}, (err: ExecException | null) => {
 						if (err) reject(err);
-						fs.readFile(path.join(dirPath, 'output.svg'), function (err: ErrnoException | null, data: Buffer) {
-							if (err) reject(err)
-							resolve(data.toString());
-						});
+						else resolve(`app://local/${path.join(dirPath, 'output.svg')}`)
 					});
 				});
 			})
@@ -162,7 +159,6 @@ ${this.settings.preamble}
 	}
 
 	onunload() {
-
 	}
 
 	async loadSettings() {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
 		"@typescript-eslint/parser": "^5.2.0",
 		"builtin-modules": "^3.2.0",
 		"esbuild": "0.13.12",
-		"node-latex": "3.1.0",
 		"obsidian": "^0.13.26",
 		"tslib": "2.3.1",
 		"typescript": "4.4.4"
 	},
 	"dependencies": {
-		"@codemirror/basic-setup": "^0.19.1"
+		"@codemirror/basic-setup": "^0.19.1",
+		"temp": "^0.9.4"
 	}
 }


### PR DESCRIPTION
This PR addresses a few issues. These modifications break things, so I didn't want to push it directly to the main branch, but first wait for feedback:

- Rendering in live preview mode (#5): Uses `registerMarkdownCodeBlockProcessor`. Registers a language alias for `tikz-render` so that syntax highlighting works
- Uses special comments for settings, such as width and height (#4)
- Uses `app://local/` links to prevent interference between rendered SVGs (#6)

A code block would now look like this:

````markdown
```tikz-render
%otr-width 10%
\node[red](a) {B};
```
````

The side-by-side mode is buggy because Prism is only loaded by obsidian when the preview mode (Ctrl+E, not live-preview) is toggled. It currently only works after the preview mode was toggled at least once. If anyone knows how to fix this, I'd be grateful for a solution.